### PR TITLE
Update python versions used into GitHub actions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        # python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        python-version: ['3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        python-version: ['3.12']
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains a Python Telegram Bot that allows users to create and s
 
 To run the Python Telegram Bot Flashcards, you'll need the following:
 
-- Python 3.6 or higher
+- Python 3.8 or higher
 
 ## Installation
 

--- a/src/flashcard.py
+++ b/src/flashcard.py
@@ -46,7 +46,8 @@ class FlashCardBot:
     def __init__(self,
                  config: dict,
                  database: str = 'flashcard.db',
-                 max_attempts: int = 3) -> None:
+                 max_attempts: int = 3,
+                 timeout: int = 20) -> None:
         '''
         Constructor of FlashCardBot class
         '''
@@ -58,7 +59,8 @@ class FlashCardBot:
         self.attempt = 0
 
         # Create table
-        self.conn = sqlite3.connect(database)
+        self.conn = sqlite3.connect(database=database,
+                                    timeout=timeout)
         self.cursor = self.conn.cursor()
         self.cursor.execute('''CREATE TABLE IF NOT EXISTS items
                             (id INTEGER PRIMARY KEY,


### PR DESCRIPTION
Set Python versions `3.8`, `3.9` and `3.10` into Github Action workflow. Version `3.11` and `3.12` to be updated after  https://github.com/ocriado91/python-telegrambot-flashcards/issues/26 due to creation of a new `StorageManager` class to manage database interface (traced to https://github.com/ocriado91/python-telegrambot-flashcards/issues/32)